### PR TITLE
Update CountriesTableSeeder.php

### DIFF
--- a/database/seeds/CountriesTableSeeder.php
+++ b/database/seeds/CountriesTableSeeder.php
@@ -63,6 +63,7 @@ class CountriesTableSeeder extends Seeder {
 			array('code' => 'CU', 'name' => 'Cuba'),
 			array('code' => 'CY', 'name' => 'Cyprus'),
 			array('code' => 'CZ', 'name' => 'Czech Republic'),
+			array('code' => 'CD', 'name' => 'Democratic Republic of Congo'),
 			array('code' => 'DK', 'name' => 'Denmark'),
 			array('code' => 'DJ', 'name' => 'Djibouti'),
 			array('code' => 'DM', 'name' => 'Dominica'),


### PR DESCRIPTION
It seems that "Democratic Republic of Congo" was missing. Probably due to the similarity with the country named "Congo". But it seems there are two different counties as described here https://en.wikipedia.org/wiki/Congo